### PR TITLE
Handle swipe properly when carousel has one slide and disable the arrows

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
   },
   "plugins": ["prettier"],
   "rules": {
+    "prettier/prettier": "error",
     "react/no-multi-comp": 0,
     "max-params": 0,
     "no-magic-numbers": 0,

--- a/demo/app.js
+++ b/demo/app.js
@@ -10,9 +10,13 @@ class App extends React.Component {
     this.state = { slideIndex: 0, length: 6, wrapAround: false };
   }
 
+  getStyleTagStyles() {
+    return '.slider-list img {width: 100%; display: block;}';
+  }
+
   render() {
     return (
-      <div style={{ width: '50%', margin: 'auto' }}>
+      <div style={{ width: '70%', margin: 'auto' }}>
         <Carousel
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
@@ -46,6 +50,15 @@ class App extends React.Component {
             <button
               onClick={() =>
                 this.setState({
+                  length: 1
+                })
+              }
+            >
+              1 Slide Only
+            </button>
+            <button
+              onClick={() =>
+                this.setState({
                   length: 2
                 })
               }
@@ -63,6 +76,11 @@ class App extends React.Component {
             </button>
           </div>
         </div>
+
+        <style
+          type="text/css"
+          dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
+        />
       </div>
     );
   }

--- a/demo/app.js
+++ b/demo/app.js
@@ -17,9 +17,13 @@ class App extends React.Component {
       placeholderMode: false,
       preloadedChildrenLevel: undefined
     };
+
+    this.updateSlideIndex = this.updateSlideIndex.bind(this);
   }
 
-  _updateSlideIndex = slideIndex => this.setState({ slideIndex })
+  updateSlideIndex(slideIndex) {
+    this.setState({ slideIndex })
+  }
 
   getStyleTagStyles() {
     return '.slider-list img {width: 100%; display: block;}';
@@ -36,7 +40,7 @@ class App extends React.Component {
           heightMode='max'
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
-          afterSlide={this._updateSlideIndex}
+          afterSlide={this.updateSlideIndex}
           renderTopCenterControls={({ currentSlide }) => (
             <div style={{ fontFamily: 'Helvetica', color: '#fff' }}>
               Nuka Carousel: Slide {currentSlide + 1}

--- a/demo/app.js
+++ b/demo/app.js
@@ -4,8 +4,8 @@ import ReactDom from 'react-dom';
 
 const colors = ['7732bb', '047cc0', '00884b', 'e3bc13', 'db7c00', 'aa231f'];
 
-const Slide = ({ imgSrc }) => <img src={imgSrc} />
-const Placeholder = ({ imgSrc }) => <div>{imgSrc}</div>
+const Slide = ({ imgSrc }) => <img src={imgSrc} />;
+const Placeholder = ({ imgSrc }) => <div>{imgSrc}</div>;
 
 class App extends React.Component {
   constructor() {
@@ -22,7 +22,7 @@ class App extends React.Component {
   }
 
   updateSlideIndex(slideIndex) {
-    this.setState({ slideIndex })
+    this.setState({ slideIndex });
   }
 
   getStyleTagStyles() {
@@ -37,7 +37,7 @@ class App extends React.Component {
           Placeholder={Placeholder}
           placeholderMode={this.state.placeholderMode}
           preloadedChildrenLevel={this.state.preloadedChildrenLevel}
-          heightMode='max'
+          heightMode="max"
           wrapAround={this.state.wrapAround}
           slideIndex={this.state.slideIndex}
           afterSlide={this.updateSlideIndex}
@@ -47,9 +47,10 @@ class App extends React.Component {
             </div>
           )}
         >
-          {colors
-            .slice(0, this.state.length)
-            .map((color, index) => ({ imgSrc: `http://placehold.it/1000x400/${color}/ffffff/&text=slide${index + 1}` }))}
+          {colors.slice(0, this.state.length).map((color, index) => ({
+            imgSrc: `http://placehold.it/1000x400/${color}/ffffff/&text=slide${index +
+              1}`
+          }))}
         </Carousel>
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <div>
@@ -94,12 +95,36 @@ class App extends React.Component {
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <div>
             preloadedChildrenLevel:
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 1 })}>1</button>
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 2 })}>2</button>
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 3 })}>3</button>
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 4 })}>4</button>
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 5 })}>5</button>
-            <button onClick={() => this.setState({ preloadedChildrenLevel: 6 })}>6</button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 1 })}
+            >
+              1
+            </button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 2 })}
+            >
+              2
+            </button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 3 })}
+            >
+              3
+            </button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 4 })}
+            >
+              4
+            </button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 5 })}
+            >
+              5
+            </button>
+            <button
+              onClick={() => this.setState({ preloadedChildrenLevel: 6 })}
+            >
+              6
+            </button>
           </div>
           <div>
             <button

--- a/lib/default-controls.js
+++ b/lib/default-controls.js
@@ -59,7 +59,7 @@ function (_React$Component) {
   }, {
     key: "render",
     value: function render() {
-      var disabled = this.props.currentSlide === 0 && !this.props.wrapAround || this.props.slideCount === 0 || this.props.slideCount === 1;
+      var disabled = this.props.currentSlide === 0 && !this.props.wrapAround || this.props.slideCount <= 1;
       return _react.default.createElement("button", {
         style: defaultButtonStyles(disabled),
         disabled: disabled,
@@ -97,7 +97,7 @@ function (_React$Component2) {
   }, {
     key: "render",
     value: function render() {
-      var disabled = this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround || this.props.slideCount === 1;
+      var disabled = this.props.slideCount <= 1 || this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount && !this.props.wrapAround;
       return _react.default.createElement("button", {
         style: defaultButtonStyles(disabled),
         disabled: disabled,

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,8 @@ function (_React$Component) {
     _this.handleMouseOut = _this.handleMouseOut.bind(_assertThisInitialized(_this));
     _this.handleClick = _this.handleClick.bind(_assertThisInitialized(_this));
     _this.handleSwipe = _this.handleSwipe.bind(_assertThisInitialized(_this));
+    _this.handleSwipeToNextSlide = _this.handleSwipeToNextSlide.bind(_assertThisInitialized(_this));
+    _this.handleSwipeToPreviousSlide = _this.handleSwipeToPreviousSlide.bind(_assertThisInitialized(_this));
     _this.swipeDirection = _this.swipeDirection.bind(_assertThisInitialized(_this));
     _this.autoplayIterator = _this.autoplayIterator.bind(_assertThisInitialized(_this));
     _this.startAutoplay = _this.startAutoplay.bind(_assertThisInitialized(_this));
@@ -397,6 +399,34 @@ function (_React$Component) {
       }
     }
   }, {
+    key: "handleSwipeToNextSlide",
+    value: function handleSwipeToNextSlide() {
+      var slidesToShow = this.props.slidesToShow;
+
+      if (this.props.slidesToScroll === 'auto') {
+        slidesToShow = this.state.slidesToScroll;
+      }
+
+      if (this.totalSlides() === 1 || this.state.currentSlide >= this.totalSlides() - slidesToShow && !this.props.wrapAround) {
+        this.setState({
+          easing: easing[this.props.edgeEasing]
+        });
+      } else {
+        this.nextSlide();
+      }
+    }
+  }, {
+    key: "handleSwipeToPreviousSlide",
+    value: function handleSwipeToPreviousSlide() {
+      if (_react.default.Children.count(this.props.children) === 1 || this.state.currentSlide <= 0 && !this.props.wrapAround) {
+        this.setState({
+          easing: easing[this.props.edgeEasing]
+        });
+      } else {
+        this.previousSlide();
+      }
+    }
+  }, {
     key: "handleSwipe",
     value: function handleSwipe() {
       if (typeof this.touchObject.length !== 'undefined' && this.touchObject.length > 44) {
@@ -413,21 +443,9 @@ function (_React$Component) {
 
       if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
         if (this.touchObject.direction === 1) {
-          if (this.state.currentSlide >= this.totalSlides() - slidesToShow && !this.props.wrapAround) {
-            this.setState({
-              easing: easing[this.props.edgeEasing]
-            });
-          } else {
-            this.nextSlide();
-          }
+          this.handleSwipeToNextSlide();
         } else if (this.touchObject.direction === -1) {
-          if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
-            this.setState({
-              easing: easing[this.props.edgeEasing]
-            });
-          } else {
-            this.previousSlide();
-          }
+          this.handleSwipeToPreviousSlide();
         }
       } else {
         this.goToSlide(this.state.currentSlide);
@@ -1025,11 +1043,6 @@ function (_React$Component) {
       };
     }
   }, {
-    key: "getStyleTagStyles",
-    value: function getStyleTagStyles() {
-      return '.slider-slide > img {width: 100%; display: block;}';
-    }
-  }, {
     key: "getDecoratorStyles",
     value: function getDecoratorStyles(position) {
       switch (position) {
@@ -1204,6 +1217,9 @@ function (_React$Component) {
       var _children = this.formatChildren(this.props.children);
 
       var duration = this.state.dragging || this.state.resetWrapAroundPosition ? 0 : this.props.speed;
+      var frameStyles = this.getFrameStyles();
+      var touchEvents = this.getTouchEvents();
+      var mouseEvents = this.getMouseEvents();
       return _react.default.createElement("div", {
         className: ['slider', this.props.className || ''].join(' '),
         style: _extends({}, this.getSliderStyles(), this.props.style)
@@ -1227,8 +1243,8 @@ function (_React$Component) {
             ref: function ref(frame) {
               return _this9.frame = frame;
             },
-            style: _this9.getFrameStyles()
-          }, _this9.getTouchEvents(), _this9.getMouseEvents(), {
+            style: frameStyles
+          }, touchEvents, mouseEvents, {
             onClick: _this9.handleClick
           }), _react.default.createElement("ul", {
             className: "slider-list",
@@ -1238,12 +1254,7 @@ function (_React$Component) {
             })
           }, _children));
         }
-      }), this.renderControls(), _react.default.createElement("style", {
-        type: "text/css",
-        dangerouslySetInnerHTML: {
-          __html: this.getStyleTagStyles()
-        }
-      }));
+      }), this.renderControls());
     }
   }]);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,13 +35,9 @@ var easing = _interopRequireWildcard(require("d3-ease"));
 
 var _defaultControls = require("./default-controls");
 
-var _Carousel$propTypes;
-
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
 
@@ -1262,7 +1258,7 @@ function (_React$Component) {
 }(_react.default.Component);
 
 exports.default = Carousel;
-Carousel.propTypes = (_Carousel$propTypes = {
+Carousel.propTypes = {
   afterSlide: _propTypes.default.func,
   autoplay: _propTypes.default.bool,
   autoplayInterval: _propTypes.default.number,
@@ -1282,8 +1278,27 @@ Carousel.propTypes = (_Carousel$propTypes = {
   preloadedChildrenLevel: _propTypes.default.number,
   renderCustomLeftControls: _propTypes.default.func,
   renderCustomRightControls: _propTypes.default.func,
-  renderCustomBottomControls: _propTypes.default.func
-}, _defineProperty(_Carousel$propTypes, "renderCustomBottomControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderTopLeftControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderTopCenterControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderTopRightControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderCenterLeftControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderCenterCenterControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderCenterRightControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderBottomLeftControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderBottomCenterControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "renderBottomRightControls", _propTypes.default.func), _defineProperty(_Carousel$propTypes, "Slide", _propTypes.default.func.isRequired), _defineProperty(_Carousel$propTypes, "slideIndex", _propTypes.default.number), _defineProperty(_Carousel$propTypes, "slidesToScroll", _propTypes.default.oneOfType([_propTypes.default.number, _propTypes.default.oneOf(['auto'])])), _defineProperty(_Carousel$propTypes, "slidesToShow", _propTypes.default.number), _defineProperty(_Carousel$propTypes, "slideWidth", _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.number])), _defineProperty(_Carousel$propTypes, "speed", _propTypes.default.number), _defineProperty(_Carousel$propTypes, "swiping", _propTypes.default.bool), _defineProperty(_Carousel$propTypes, "vertical", _propTypes.default.bool), _defineProperty(_Carousel$propTypes, "width", _propTypes.default.string), _defineProperty(_Carousel$propTypes, "wrapAround", _propTypes.default.bool), _Carousel$propTypes);
+  renderCustomBottomControls: _propTypes.default.func,
+  renderTopLeftControls: _propTypes.default.func,
+  renderTopCenterControls: _propTypes.default.func,
+  renderTopRightControls: _propTypes.default.func,
+  renderCenterLeftControls: _propTypes.default.func,
+  renderCenterCenterControls: _propTypes.default.func,
+  renderCenterRightControls: _propTypes.default.func,
+  renderBottomLeftControls: _propTypes.default.func,
+  renderBottomCenterControls: _propTypes.default.func,
+  renderBottomRightControls: _propTypes.default.func,
+  Slide: _propTypes.default.func.isRequired,
+  slideIndex: _propTypes.default.number,
+  slidesToScroll: _propTypes.default.oneOfType([_propTypes.default.number, _propTypes.default.oneOf(['auto'])]),
+  slidesToShow: _propTypes.default.number,
+  slideWidth: _propTypes.default.oneOfType([_propTypes.default.string, _propTypes.default.number]),
+  speed: _propTypes.default.number,
+  swiping: _propTypes.default.bool,
+  vertical: _propTypes.default.bool,
+  width: _propTypes.default.string,
+  wrapAround: _propTypes.default.bool
+};
 Carousel.defaultProps = {
   afterSlide: function afterSlide() {},
   autoplay: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -418,7 +418,7 @@ function (_React$Component) {
   }, {
     key: "handleSwipeToPreviousSlide",
     value: function handleSwipeToPreviousSlide() {
-      if (_react.default.Children.count(this.props.children) === 1 || this.state.currentSlide <= 0 && !this.props.wrapAround) {
+      if (this.totalSlides() === 1 || this.state.currentSlide <= 0 && !this.props.wrapAround) {
         this.setState({
           easing: easing[this.props.edgeEasing]
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuka-carousel",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Pure React Carousel",
   "main": "index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuka-carousel",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Pure React Carousel",
   "main": "index.js",
   "module": "es/index.js",

--- a/src/default-controls.js
+++ b/src/default-controls.js
@@ -22,7 +22,7 @@ export class PreviousButton extends React.Component {
   render() {
     const disabled =
       (this.props.currentSlide === 0 && !this.props.wrapAround) ||
-      this.props.slideCount === 0;
+      this.props.slideCount <= 1;
     return (
       <button
         style={defaultButtonStyles(disabled)}
@@ -46,8 +46,10 @@ export class NextButton extends React.Component {
   }
   render() {
     const disabled =
-      this.props.currentSlide + this.props.slidesToScroll >=
-        this.props.slideCount && !this.props.wrapAround;
+      this.props.slideCount <= 1 ||
+      (this.props.currentSlide + this.props.slidesToScroll >=
+        this.props.slideCount &&
+        !this.props.wrapAround);
     return (
       <button
         style={defaultButtonStyles(disabled)}

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,10 @@ export default class Carousel extends React.Component {
     this.handleMouseOut = this.handleMouseOut.bind(this);
     this.handleClick = this.handleClick.bind(this);
     this.handleSwipe = this.handleSwipe.bind(this);
+    this.handleSwipeToNextSlide = this.handleSwipeToNextSlide.bind(this);
+    this.handleSwipeToPreviousSlide = this.handleSwipeToPreviousSlide.bind(
+      this
+    );
     this.swipeDirection = this.swipeDirection.bind(this);
     this.autoplayIterator = this.autoplayIterator.bind(this);
     this.startAutoplay = this.startAutoplay.bind(this);
@@ -317,6 +321,35 @@ export default class Carousel extends React.Component {
     }
   }
 
+  handleSwipeToNextSlide() {
+    let slidesToShow = this.props.slidesToShow;
+    if (this.props.slidesToScroll === 'auto') {
+      slidesToShow = this.state.slidesToScroll;
+    }
+
+    if (
+      React.Children.count(this.props.children) === 1 ||
+      (this.state.currentSlide >=
+        React.Children.count(this.props.children) - slidesToShow &&
+        !this.props.wrapAround)
+    ) {
+      this.setState({ easing: easing[this.props.edgeEasing] });
+    } else {
+      this.nextSlide();
+    }
+  }
+
+  handleSwipeToPreviousSlide() {
+    if (
+      React.Children.count(this.props.children) === 1 ||
+      (this.state.currentSlide <= 0 && !this.props.wrapAround)
+    ) {
+      this.setState({ easing: easing[this.props.edgeEasing] });
+    } else {
+      this.previousSlide();
+    }
+  }
+
   handleSwipe() {
     if (
       typeof this.touchObject.length !== 'undefined' &&
@@ -334,21 +367,9 @@ export default class Carousel extends React.Component {
 
     if (this.touchObject.length > this.state.slideWidth / slidesToShow / 5) {
       if (this.touchObject.direction === 1) {
-        if (
-          this.state.currentSlide >=
-            React.Children.count(this.props.children) - slidesToShow &&
-          !this.props.wrapAround
-        ) {
-          this.setState({ easing: easing[this.props.edgeEasing] });
-        } else {
-          this.nextSlide();
-        }
+        this.handleSwipeToNextSlide();
       } else if (this.touchObject.direction === -1) {
-        if (this.state.currentSlide <= 0 && !this.props.wrapAround) {
-          this.setState({ easing: easing[this.props.edgeEasing] });
-        } else {
-          this.previousSlide();
-        }
+        this.handleSwipeToPreviousSlide();
       }
     } else {
       this.goToSlide(this.state.currentSlide);
@@ -876,10 +897,6 @@ export default class Carousel extends React.Component {
     };
   }
 
-  getStyleTagStyles() {
-    return '.slider-slide > img {width: 100%; display: block;}';
-  }
-
   getDecoratorStyles(position) {
     switch (position) {
       case 'TopLeft': {
@@ -1063,11 +1080,6 @@ export default class Carousel extends React.Component {
         />
 
         {this.renderControls()}
-
-        <style
-          type="text/css"
-          dangerouslySetInnerHTML={{ __html: this.getStyleTagStyles() }}
-        />
       </div>
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -829,7 +829,10 @@ export default class Carousel extends React.Component {
     const end =
       (this.state.slideWidth + this.props.cellSpacing) * slidesToShow * -1;
 
-    if (this.props.wrapAround) {
+    if (
+      this.props.wrapAround &&
+      (this.state.isWrappingAround || this.state.dragging)
+    ) {
       const slidesBefore = Math.ceil(positionValue / this.state.slideWidth);
       if (this.state.slideCount - slidesBefore <= index) {
         return (

--- a/src/index.js
+++ b/src/index.js
@@ -1025,9 +1025,9 @@ export default class Carousel extends React.Component {
         ? 0
         : this.props.speed;
 
-    const frameStyles = this.getFrameStyles()
-    const touchEvents = this.getTouchEvents()
-    const mouseEvents = this.getMouseEvents()
+    const frameStyles = this.getFrameStyles();
+    const touchEvents = this.getTouchEvents();
+    const mouseEvents = this.getMouseEvents();
 
     return (
       <div

--- a/src/index.js
+++ b/src/index.js
@@ -1025,6 +1025,10 @@ export default class Carousel extends React.Component {
         ? 0
         : this.props.speed;
 
+    const frameStyles = this.getFrameStyles()
+    const touchEvents = this.getTouchEvents()
+    const mouseEvents = this.getMouseEvents()
+
     return (
       <div
         className={['slider', this.props.className || ''].join(' ')}
@@ -1043,9 +1047,9 @@ export default class Carousel extends React.Component {
             <div
               className="slider-frame"
               ref={frame => (this.frame = frame)}
-              style={this.getFrameStyles()}
-              {...this.getTouchEvents()}
-              {...this.getMouseEvents()}
+              style={frameStyles}
+              {...touchEvents}
+              {...mouseEvents}
               onClick={this.handleClick}
             >
               <ul

--- a/src/index.js
+++ b/src/index.js
@@ -357,7 +357,7 @@ export default class Carousel extends React.Component {
 
   handleSwipeToPreviousSlide() {
     if (
-      React.Children.count(this.props.children) === 1 ||
+      this.totalSlides() === 1 ||
       (this.state.currentSlide <= 0 && !this.props.wrapAround)
     ) {
       this.setState({ easing: easing[this.props.edgeEasing] });

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ export default class Carousel extends React.Component {
 
   // TODO check why is this needed
   componentDidUpdate() {
-    this.updateDimensions()
+    this.updateDimensions();
   }
 
   componentWillUnmount() {
@@ -345,8 +345,7 @@ export default class Carousel extends React.Component {
 
     if (
       this.totalSlides() === 1 ||
-      (this.state.currentSlide >=
-      this.totalSlides() - slidesToShow &&
+      (this.state.currentSlide >= this.totalSlides() - slidesToShow &&
         !this.props.wrapAround)
     ) {
       this.setState({ easing: easing[this.props.edgeEasing] });
@@ -466,7 +465,7 @@ export default class Carousel extends React.Component {
   goToSlide(index) {
     this.setState({ easing: easing[this.props.easing] });
 
-    if ((index >= this.totalSlides() || index < 0)) {
+    if (index >= this.totalSlides() || index < 0) {
       if (!this.props.wrapAround) {
         return;
       }
@@ -504,8 +503,7 @@ export default class Carousel extends React.Component {
         );
         return;
       } else {
-        const endSlide =
-          this.totalSlides() - this.state.slidesToScroll;
+        const endSlide = this.totalSlides() - this.state.slidesToScroll;
         this.props.beforeSlide(this.state.currentSlide, endSlide);
         this.setState(
           prevState => ({
@@ -665,53 +663,67 @@ export default class Carousel extends React.Component {
   }
 
   shouldRenderSlide(index) {
-    const { Placeholder, placeholderMode, preloadedChildrenLevel, wrapAround } = this.props
+    const {
+      Placeholder,
+      placeholderMode,
+      preloadedChildrenLevel,
+      wrapAround
+    } = this.props;
 
     if (!placeholderMode || !Placeholder) {
-      return true
+      return true;
     }
 
-    const currentSlide = this.state.currentSlide
-    const totalPreloadedSlides = 2 * preloadedChildrenLevel + 1
-    const totalSlides = this.totalSlides()
+    const currentSlide = this.state.currentSlide;
+    const totalPreloadedSlides = 2 * preloadedChildrenLevel + 1;
+    const totalSlides = this.totalSlides();
 
     if (wrapAround) {
       if (totalPreloadedSlides >= totalSlides) {
         // should render all slides
-        return true
+        return true;
       }
 
       if (currentSlide + preloadedChildrenLevel > totalSlides - 1) {
         // if last index of preloaded children goes out of bounds, split the preloaded children set into 2 sets
-        return (index >= 0 && index <= (currentSlide + preloadedChildrenLevel - totalSlides)) ||
-          (index >= (currentSlide - preloadedChildrenLevel) && index <= totalSlides - 1)
+        return (
+          (index >= 0 &&
+            index <= currentSlide + preloadedChildrenLevel - totalSlides) ||
+          (index >= currentSlide - preloadedChildrenLevel &&
+            index <= totalSlides - 1)
+        );
       }
 
       if (currentSlide - preloadedChildrenLevel < 0) {
         // if first index of preloaded children goes out of bounds, split the preloaded children set into 2 sets
-        return (index >= 0 && index <= currentSlide + preloadedChildrenLevel) ||
-          (index >= (currentSlide - preloadedChildrenLevel + totalSlides) && index <= totalSlides - 1)
+        return (
+          (index >= 0 && index <= currentSlide + preloadedChildrenLevel) ||
+          (index >= currentSlide - preloadedChildrenLevel + totalSlides &&
+            index <= totalSlides - 1)
+        );
       }
 
-      return (index >= currentSlide - preloadedChildrenLevel) &&
-        (index <= currentSlide + preloadedChildrenLevel)
+      return (
+        index >= currentSlide - preloadedChildrenLevel &&
+        index <= currentSlide + preloadedChildrenLevel
+      );
     } else {
-      return index >= 0 &&
+      return (
+        index >= 0 &&
         index <= totalSlides - 1 &&
         index >= currentSlide - preloadedChildrenLevel &&
         index <= currentSlide + preloadedChildrenLevel
+      );
     }
   }
 
   formatChildren() {
-    const { children, vertical, Slide, Placeholder } = this.props
+    const { children, vertical, Slide, Placeholder } = this.props;
     if (!children) {
-      return null
+      return null;
     }
 
-    const positionValue = vertical
-      ? this.state.top
-      : this.state.left;
+    const positionValue = vertical ? this.state.top : this.state.left;
     return children.map((slide, index) => {
       return (
         <li
@@ -719,18 +731,18 @@ export default class Carousel extends React.Component {
           style={this.getSlideStyles(index, positionValue)}
           key={index}
         >
-          {
-            this.shouldRenderSlide(index)
-              ? Slide && <Slide {...slide} />
-              : <Placeholder {...slide} />
-          }
+          {this.shouldRenderSlide(index) ? (
+            Slide && <Slide {...slide} />
+          ) : (
+            <Placeholder {...slide} />
+          )}
         </li>
       );
     });
   }
 
   totalSlides() {
-    return this.props.children ? this.props.children.length : 0
+    return this.props.children ? this.props.children.length : 0;
   }
 
   setInitialDimensions() {
@@ -820,9 +832,10 @@ export default class Carousel extends React.Component {
     const slideWidth = this.getSlideWidth(props, frame, slideHeight);
     const frameWidth = this.getFrameWidth(props, frame, slideHeight);
 
-    const slidesToScroll = props.slidesToScroll === 'auto'
-      ? Math.floor(frameWidth / (slideWidth + props.cellSpacing))
-      : props.slidesToScroll
+    const slidesToScroll =
+      props.slidesToScroll === 'auto'
+        ? Math.floor(frameWidth / (slideWidth + props.cellSpacing))
+        : props.slidesToScroll;
 
     this.setState(
       {
@@ -840,9 +853,11 @@ export default class Carousel extends React.Component {
   }
 
   dimensionsChanged(newDimensions) {
-    return newDimensions.slideHeight !== this.state.slideHeight ||
+    return (
+      newDimensions.slideHeight !== this.state.slideHeight ||
       newDimensions.frameWidth !== this.state.frameWidth ||
       newDimensions.slideWidth !== this.state.slideWidth
+    );
   }
 
   updateDimensions() {
@@ -972,13 +987,15 @@ export default class Carousel extends React.Component {
 
     if (this.props.wrapAround && this.state.slideCount > 2) {
       if (index === 0) {
-        if (this.state.currentSlide === this.state.slideCount - 1) { // last slide is active
-          return (fullSlideWidth * (this.state.slideCount + index));
+        if (this.state.currentSlide === this.state.slideCount - 1) {
+          // last slide is active
+          return fullSlideWidth * (this.state.slideCount + index);
         }
       }
 
       if (index === this.state.slideCount - 1) {
-        if (this.state.currentSlide === 0) { // first slide is active
+        if (this.state.currentSlide === 0) {
+          // first slide is active
           return fullSlideWidth * (this.state.slideCount - index) * -1;
         }
       }
@@ -1078,11 +1095,11 @@ export default class Carousel extends React.Component {
           bottom: 0,
           right: 0
         };
-        }
+      }
       case 'CustomLeft':
       case 'CustomRight':
       case 'CustomBottom': {
-        return null
+        return null;
       }
       default: {
         return {
@@ -1112,10 +1129,11 @@ export default class Carousel extends React.Component {
   }
 
   renderControls() {
-    return controlsMap.map(
-      ({ funcName, key }) => {
-        const func = this.props[funcName]
-        return func && typeof func === 'function' && (
+    return controlsMap.map(({ funcName, key }) => {
+      const func = this.props[funcName];
+      return (
+        func &&
+        typeof func === 'function' && (
           <div
             className={`slider-control-${key.toLowerCase()}`}
             style={this.getDecoratorStyles(key)}
@@ -1136,12 +1154,12 @@ export default class Carousel extends React.Component {
             })}
           </div>
         )
-      }
-    );
+      );
+    });
   }
 
   render() {
-    const children = this.formatChildren(this.props.children)
+    const children = this.formatChildren(this.props.children);
     const duration =
       this.state.dragging || this.state.resetWrapAroundPosition
         ? 0
@@ -1210,7 +1228,6 @@ Carousel.propTypes = {
   preloadedChildrenLevel: PropTypes.number,
   renderCustomLeftControls: PropTypes.func,
   renderCustomRightControls: PropTypes.func,
-  renderCustomBottomControls: PropTypes.func,
   renderCustomBottomControls: PropTypes.func,
   renderTopLeftControls: PropTypes.func,
   renderTopCenterControls: PropTypes.func,

--- a/test/specs/carousel.test.js
+++ b/test/specs/carousel.test.js
@@ -1,69 +1,46 @@
 import Carousel from '../../src';
 
-const createSlidesData = (numberOfSlides = 3) => Array.from({ length: numberOfSlides }, (v, k) => `Slide ${k + 1}`);
+const createSlidesData = (numberOfSlides = 3) =>
+  Array.from({ length: numberOfSlides }, (v, k) => `Slide ${k + 1}`);
 
-const data = createSlidesData(3)
-const Slide = ({ text }) => <p>{text}</p>
-const Placeholder = ({ text }) => <p>{`Placeholder for ${text}`}</p>
+const data = createSlidesData(3);
+const Slide = ({ text }) => <p>{text}</p>;
+const Placeholder = ({ text }) => <p>{`Placeholder for ${text}`}</p>;
 
 describe('<Carousel />', () => {
   describe('Rendering and Mounting', () => {
     it('should correctly mount with children.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const children = wrapper.find('p');
       expect(children).toHaveLength(3);
     });
 
     it('should render a div with the class `slider`.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const sliderDiv = wrapper.find('div.slider');
       expect(sliderDiv).toHaveLength(1);
     });
 
     it('should render a div with the class `slider-frame`.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const sliderFrameDiv = wrapper.find('div.slider-frame');
       expect(sliderFrameDiv).toHaveLength(1);
     });
 
     it('should render an ul with the class `slider-list`.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const sliderListUl = wrapper.find('ul.slider-list');
       expect(sliderListUl).toHaveLength(1);
     });
 
     it('should render children with the `slider-slide` class.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const children = wrapper.find('.slider-slide');
       expect(children).toHaveLength(3);
     });
 
     it('should render controls by default.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const decorator1 = wrapper.find('.slider-control-centerleft');
       const decorator2 = wrapper.find('.slider-control-centerright');
       const decorator3 = wrapper.find('.slider-control-bottomcenter');
@@ -75,11 +52,7 @@ describe('<Carousel />', () => {
 
   describe('Props', () => {
     it('should render with the class `slider` when no props are supplied.', () => {
-      const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {data}
-        </Carousel>
-      );
+      const wrapper = mount(<Carousel Slide={Slide}>{data}</Carousel>);
       const slider = wrapper.find('div.slider');
       expect(slider).toHaveLength(1);
     });
@@ -182,7 +155,9 @@ describe('<Carousel />', () => {
           { offsetHeight: 200, style: {} },
           { offsetHeight: 300, style: {} }
         ]);
-      const CustomSlide = ({ text, height }) =>  <div style={{ height }}>{text}</div>
+      const CustomSlide = ({ text, height }) => (
+        <div style={{ height }}>{text}</div>
+      );
       const wrapper = mount(
         <Carousel Slide={CustomSlide} heightMode="max">
           {[
@@ -213,7 +188,9 @@ describe('<Carousel />', () => {
           { offsetHeight: 200, style: {} },
           { offsetHeight: 300, style: {} }
         ]);
-      const CustomSlide = ({ text, height }) =>  <div style={{ height }}>{text}</div>
+      const CustomSlide = ({ text, height }) => (
+        <div style={{ height }}>{text}</div>
+      );
       const wrapper = mount(
         <Carousel Slide={CustomSlide} heightMode="first">
           {[
@@ -244,7 +221,9 @@ describe('<Carousel />', () => {
           { offsetHeight: 200, style: {} },
           { offsetHeight: 300, style: {} }
         ]);
-      const CustomSlide = ({ text, height }) =>  <div style={{ height }}>{text}</div>
+      const CustomSlide = ({ text, height }) => (
+        <div style={{ height }}>{text}</div>
+      );
       const wrapper = mount(
         <Carousel Slide={CustomSlide} heightMode="current" slideIndex={1}>
           {[
@@ -357,7 +336,10 @@ describe('<Carousel />', () => {
   describe('Controls', () => {
     it('should render a custom left control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCustomLeftControls={() => <div>Custom Left</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCustomLeftControls={() => <div>Custom Left</div>}
+        >
           {data}
         </Carousel>
       );
@@ -366,7 +348,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom right control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCustomRightControls={() => <div>Custom Right</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCustomRightControls={() => <div>Custom Right</div>}
+        >
           {data}
         </Carousel>
       );
@@ -375,7 +360,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom bottom control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCustomBottomControls={() => <div>Custom Bottom</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCustomBottomControls={() => <div>Custom Bottom</div>}
+        >
           {data}
         </Carousel>
       );
@@ -384,7 +372,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom top left control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderTopLeftControls={() => <div>Top Left</div>}>
+        <Carousel
+          Slide={Slide}
+          renderTopLeftControls={() => <div>Top Left</div>}
+        >
           {data}
         </Carousel>
       );
@@ -393,7 +384,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom top center control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderTopCenterControls={() => <div>Top Center</div>}>
+        <Carousel
+          Slide={Slide}
+          renderTopCenterControls={() => <div>Top Center</div>}
+        >
           {data}
         </Carousel>
       );
@@ -402,7 +396,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom top right control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderTopRightControls={() => <div>Top Right</div>}>
+        <Carousel
+          Slide={Slide}
+          renderTopRightControls={() => <div>Top Right</div>}
+        >
           {data}
         </Carousel>
       );
@@ -411,7 +408,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom center left control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCenterLeftControls={() => <div>Center Left</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCenterLeftControls={() => <div>Center Left</div>}
+        >
           {data}
         </Carousel>
       );
@@ -420,7 +420,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom center center control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCenterCenterControls={() => <div>Center Center</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCenterCenterControls={() => <div>Center Center</div>}
+        >
           {data}
         </Carousel>
       );
@@ -429,7 +432,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom center right control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderCenterRightControls={() => <div>Center Right</div>}>
+        <Carousel
+          Slide={Slide}
+          renderCenterRightControls={() => <div>Center Right</div>}
+        >
           {data}
         </Carousel>
       );
@@ -438,7 +444,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom bottom left control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderBottomLeftControls={() => <div>Bottom Left</div>}>
+        <Carousel
+          Slide={Slide}
+          renderBottomLeftControls={() => <div>Bottom Left</div>}
+        >
           {data}
         </Carousel>
       );
@@ -447,7 +456,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom bottom center control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderBottomCenterControls={() => <div>Bottom Center</div>}>
+        <Carousel
+          Slide={Slide}
+          renderBottomCenterControls={() => <div>Bottom Center</div>}
+        >
           {data}
         </Carousel>
       );
@@ -456,7 +468,10 @@ describe('<Carousel />', () => {
 
     it('should render a custom bottom right control.', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} renderBottomRightControls={() => <div>Bottom Right</div>}>
+        <Carousel
+          Slide={Slide}
+          renderBottomRightControls={() => <div>Bottom Right</div>}
+        >
           {data}
         </Carousel>
       );
@@ -546,9 +561,7 @@ describe('<Carousel />', () => {
 
     it('should render all Slides', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide}>
-          {createSlidesData(6)}
-        </Carousel>
+        <Carousel Slide={Slide}>{createSlidesData(6)}</Carousel>
       );
 
       expect(wrapper.instance().shouldRenderSlide(0)).toEqual(true);
@@ -591,7 +604,12 @@ describe('<Carousel />', () => {
 
     it('should render Slides and Placeholders when placeholderMode is activated and wrapAround is set (preloadedChildrenLevel is taken in consideration)', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode wrapAround>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          wrapAround
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -606,7 +624,12 @@ describe('<Carousel />', () => {
 
     it('should render Slides and Placeholders when placeholderMode is activated and preloadedChildrenLevel is set', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={2}>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={2}
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -621,7 +644,13 @@ describe('<Carousel />', () => {
 
     it('should render Slides and Placeholders when placeholderMode is activated and wrapAround and preloadedChildrenLevel are set', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={2} wrapAround>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={2}
+          wrapAround
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -636,7 +665,12 @@ describe('<Carousel />', () => {
 
     it('should render all Slides when placeholderMode is activated and preloadedChildrenLevel is set (preloadedChildrenLevel covers all slides)', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={5}>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={5}
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -651,7 +685,13 @@ describe('<Carousel />', () => {
 
     it('should render all Slides when placeholderMode is activated and wrapAround and preloadedChildrenLevel are set (preloadedChildrenLevel covers all slides)', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={3} wrapAround>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={3}
+          wrapAround
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -687,7 +727,12 @@ describe('<Carousel />', () => {
 
     it('should render Slides and Placeholders when placeholderMode is activated and preloadedChildrenLevel is 0', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={0}>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={0}
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -702,7 +747,12 @@ describe('<Carousel />', () => {
 
     it('should render Placeholders when placeholderMode is activated and preloadedChildrenLevel is -1', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={-1}>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={-1}
+        >
           {createSlidesData(6)}
         </Carousel>
       );
@@ -717,7 +767,13 @@ describe('<Carousel />', () => {
 
     it('should render Placeholders when placeholderMode is activated and wrapAround is set and preloadedChildrenLevel is -2', () => {
       const wrapper = mount(
-        <Carousel Slide={Slide} Placeholder={Placeholder} placeholderMode preloadedChildrenLevel={-2} wrapAround>
+        <Carousel
+          Slide={Slide}
+          Placeholder={Placeholder}
+          placeholderMode
+          preloadedChildrenLevel={-2}
+          wrapAround
+        >
           {createSlidesData(6)}
         </Carousel>
       );


### PR DESCRIPTION
* Extend the demo to include option for showing only one slide
* Move getStyleTagStyles from carousel to the demo app (the user should be responsible to apply the proper styles of the slides)
* Disable the arrows when there is only one slide
* When swiping and there is only one slide, apply easing, instead of going to the next/previous slide